### PR TITLE
Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/src/shares/re.ts
+++ b/src/shares/re.ts
@@ -169,7 +169,7 @@ export const regexp = {
 	reAttr: compile(
 		/^\s*([^=\s]+)(?:\s*=\s*("[^"]+"|'[^']+'|[^>\s]+))?/,
 	) as RegExp,
-	reComment: compile(/^<!--(.+?)-->/, "s") as RegExp,
+	reComment: compile(/^<!--([\s\S]+?)-->/, "s") as RegExp,
 	reEndTag: compile(/^<\/([:html_id:])([^>]*)>/) as RegExp,
 	reTag: compile(
 		/^<([:html_id:])((?:\s[^=\s/]+(?:\s*=\s*[:html_attr:])?)+)?\s*(\/?)>/,


### PR DESCRIPTION
Potential fix for [https://github.com/phothinmg/textile-ts/security/code-scanning/2](https://github.com/phothinmg/textile-ts/security/code-scanning/2)

To fix the problem, we need to ensure that the regular expression used to match HTML comments can handle comments containing newlines. The best way to do this in JavaScript is to use the dotAll (`"s"`) flag, which allows the dot (`.`) to match newline characters. The code already attempts to do this by passing `"s"` as the second argument to the `compile` function. However, to be absolutely certain, we should verify that the `compile` function correctly applies the `"s"` flag to the RegExp constructor. If it does not, we should update the regex to use `([\s\S]+?)` instead of `(.+?)`, which matches any character including newlines, regardless of flags. This approach is robust and works in all environments.

Therefore, in the file `src/shares/re.ts`, on line 172, replace `^<!--(.+?)-->` with `^<!--([\s\S]+?)-->`. This change ensures that the regex matches comments containing newlines, even if the `"s"` flag is not applied.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
